### PR TITLE
Fixing deprication warnings.

### DIFF
--- a/lib/radiustar/old_hash.rb
+++ b/lib/radiustar/old_hash.rb
@@ -3,10 +3,8 @@
 # the same interface to the radiustar libs.
 #
 class Hash
-  # Implementation of the ruby-1.9.x key function:
-  # http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-key
-  def key(value)
-    self.index value
+  unless {}.respond_to?(:key)
+    alias_method :key, :index
   end
 end
 


### PR DESCRIPTION
Monkey patching hash's key method even when it's defined is a bad idea.
