### PR TITLE
Update ipaddr_extensions dependency

### DIFF
--- a/radiustar.gemspec
+++ b/radiustar.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<ipaddr_extensions>, ["~> 1.0"])
+      s.add_runtime_dependency(%q<ipaddr_extensions>, ["~> 1.0.0"])
       s.add_development_dependency(%q<bones>, [">= 3.7.3"])
     else
       s.add_dependency(%q<ipaddr_extensions>, ["~> 1.0.0"])


### PR DESCRIPTION
On May 20 2013 1.0.0. version of `ipaddr_extensions` gem has been released.
All previous versions has been yanked.
Here is [prooflink](http://github.com).

There is some issue with version comparison of that gem.
`ipaddr_extensions` didn't use to use semversion. 

If specversion is `>= 1.0.0`, on node (which has version like `2012.1.13`) will be ok, but another node (which hasn't such  a gem) will fail.
So I propose to use `-> 1.0.0`.
