### PR TITLE
ipaddr 2012.1.13 is no longer available

### DIFF
--- a/radiustar.gemspec
+++ b/radiustar.gemspec
@@ -23,14 +23,14 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      #s.add_runtime_dependency(%q<ipaddr_extensions>, [">= 2012.1.13"])
+      s.add_runtime_dependency(%q<ipaddr_extensions>, ["1.0.0"])
       s.add_development_dependency(%q<bones>, [">= 3.7.3"])
     else
-      #s.add_dependency(%q<ipaddr_extensions>, [">= 2012.1.13"])
+      s.add_dependency(%q<ipaddr_extensions>, ["1.0.0"])
       s.add_dependency(%q<bones>, [">= 3.7.3"])
     end
   else
-    #s.add_dependency(%q<ipaddr_extensions>, [">= 2012.1.13"])
+    s.add_dependency(%q<ipaddr_extensions>, ["1.0.0"])
     s.add_dependency(%q<bones>, [">= 3.7.3"])
   end
 end


### PR DESCRIPTION
Updated radiustar.gemspec for ipaddr "1.0.0", version 2012.1.13 has been yanked
