### PR TITLE
Fix compatibility problem with Ruby 2.x

### DIFF
--- a/lib/radiustar/packet.rb
+++ b/lib/radiustar/packet.rb
@@ -192,14 +192,10 @@ module Radiustar
     end
 
     def xor_str(str1, str2)
-      i = 0
-      newstr = ""
-      str1.each_byte do |c1|
-        c2 = str2.bytes.to_a[i]
-        newstr = newstr << (c1 ^ c2)
-        i = i+1
-      end
-      newstr
+      bstr1 = str1.unpack('C*')
+      bstr2 = str2.unpack('C*')
+
+      bstr1.zip(bstr2).map {|b1, b2| b1 ^ b2}.pack('C*')
     end
 
     def encode(value, secret)


### PR DESCRIPTION
Hi,

I have fixed compatibility with Ruby 2.x (base on @Paulche [fix](https://github.com/Paulche/radiustar/blob/d3be443c0152b1f107074dcad6977cfe3a0b42a0/lib/radiustar/packet.rb#L195)).

@pjdavis Could you please merge it and publish new version? I am going to update devise-radius-authenticatable gem after that.

Thanks
