### PR TITLE
Fix VSA attribute_value unpacking length

### DIFF
--- a/lib/radiustar/packet.rb
+++ b/lib/radiustar/packet.rb
@@ -158,7 +158,7 @@ module Radiustar
         attribute_type = attribute_type.to_i
 
         if attribute_type == 26 # Vendor Specific Attribute
-          vid, attribute_type, attribute_value = attribute_data.unpack("xxNCxa#{length-6}")
+          vid, attribute_type, attribute_value = attribute_data.unpack("xxNCxa#{length-8}")
           vendor =  @dict.vendors.find_by_id(vid)
           attribute = vendor.find_attribute_by_id(attribute_type) if vendor
         else


### PR DESCRIPTION
xxNCx = 8 bytes, not 6.
Note for future:
Current Vendor Specific Attribute unpacking method doesn't support multiple subattributes - "vendor length" is ignored (https://tools.ietf.org/html/rfc2865#section-5.26). If multiple subattributes are encoded within a single Vendor-Specific attribute, additional loop is needed to unpack "attribute_value" again by "vendor length" byte.