### PR TITLE
Multiple values for one attribute + return reply on generic request

### DIFF
--- a/lib/radiustar/dictionary.rb
+++ b/lib/radiustar/dictionary.rb
@@ -65,7 +65,7 @@ module Radiustar
       file = File.open(path) do |f|
         current_vendor = nil
         f.each_line do |line|
-          next if line =~ /^\#/	# discard comments
+          next if line =~ /^\#/  # discard comments
           split_line = line.split(/\s+/)
           next if split_line == []
           case split_line.first.upcase
@@ -86,7 +86,7 @@ module Radiustar
       file = File.open(path) do |f|
         current_vendor = nil
         f.each_line do |line|
-          next if line =~ /^\#/	# discard comments
+          next if line =~ /^\#/  # discard comments
           split_line = line.split(/\s+/)
           next if split_line == []
           case split_line.first.upcase
@@ -132,9 +132,10 @@ module Radiustar
     end
 
     def set_vendor_value(vendor, line)
-      vendor.find_attribute_by_name(line[1]).add_value(line[2], line[3])
+       if attr = vendor.find_attribute_by_name(line[1])
+        attr.add_value(line[2], line[3])
+      end
     end
-
   end
 
 end

--- a/lib/radiustar/packet.rb
+++ b/lib/radiustar/packet.rb
@@ -106,7 +106,12 @@ module Radiustar
     end
 
     def set_attribute(name, value)
-      @attributes[name] = Attribute.new(@dict, name, value)
+      if value.is_a? Array
+        @attributes[name] ||= []
+        value.each { |v| @attributes[name] << Attribute.new(@dict, name, v) }
+      else
+        @attributes[name] = Attribute.new(@dict, name, value)
+      end
     end
 
     def unset_attribute(name)
@@ -136,7 +141,11 @@ module Radiustar
     def pack
       attstr = ""
       @attributes.values.each do |attribute|
-        attstr += attribute.pack
+        if attribute.is_a? Array
+          attribute.each { |a| attstr += a.pack }
+        else
+          attstr += attribute.pack
+        end
       end
       @packed = [CODES[@code], @id, attstr.length + HDRLEN, @authenticator, attstr].pack(P_HDR)
     end

--- a/lib/radiustar/request.rb
+++ b/lib/radiustar/request.rb
@@ -15,7 +15,7 @@ module Radiustar
 
       @port = Socket.getservbyname("radius", "udp") unless @port
       @port = 1812 unless @port
-      @port = @port.to_i	# just in case
+      @port = @port.to_i  # just in case
       @socket = UDPSocket.open
       @socket.connect(@host, @port)
     end
@@ -97,7 +97,8 @@ module Radiustar
         raise
       end
 
-      return true
+      reply = { :code => @received_packet.code }
+      reply.merge @received_packet.attributes
     end
 
     def coa_request(secret, user_attributes = {})


### PR DESCRIPTION
Make generic radius request return the response instead of just true/false.  
This is needed for proper CoA operation.
Allow multiple attribute/value pairs with the same attribute
name. Example: attrs = { 'Cisco/Cisco-AVPair' => [ '1234', '5678' ] }